### PR TITLE
[Feature] Load mods from ztds and insert into database

### DIFF
--- a/src/PConfigMgr.cpp
+++ b/src/PConfigMgr.cpp
@@ -43,6 +43,25 @@ QString PConfigMgr::getKeyValue(const QString &key, const toml::table &config)
     return QString("");
 }
 
+// Get a key value from a toml table as a list (ie tags and authors)
+QVector<QString> PConfigMgr::getKeyValueAsList(const QString &key, const toml::table &config)
+{
+    QVector<QString> result;
+
+    // Find value in table
+    if (auto it = config.find(key.toStdString()); it != config.end()) {
+        if (auto arrVal = it->second.as_array()) {
+            for (const auto &item : *arrVal) {
+                if (auto strVal = item.as_string()) {
+                    result.append(QString::fromStdString(strVal->get()));
+                }
+            }
+        }
+    }
+
+    return result;
+}
+
 // Updates the meta configuration in a ztd file
 // TODO: Test if this updates the config correctly
 // - Possible issue with old config not being removed

--- a/src/PConfigMgr.h
+++ b/src/PConfigMgr.h
@@ -13,6 +13,7 @@ public:
     ~PConfigMgr();
     static toml::table getMetaConfig(const QString &ztdFilePath);
     static QString getKeyValue(const QString &key, const toml::table &config);
+    static QVector<QString> getKeyValueAsList(const QString &key, const toml::table &config);
     static bool updateMetaConfig(const QString &ztdFilePath, const toml::table &config);
     static bool removeMetaConfig(const QString &ztdFilePath);
     toml::table getZooIniConfig(const QString &iniPath);

--- a/src/PController.cpp
+++ b/src/PController.cpp
@@ -203,26 +203,21 @@ void PController::loadModsFromZTDs(const QStringList &ztdList)
     // Insert mods into database
     for (const QString &ztd : ztdList)
     {
+        // Get meta config from ztd
         toml::table config = PConfigMgr::getMetaConfig(ztd);
-        QString title = PConfigMgr::getKeyValue("name", config);
-        QString authors = PConfigMgr::getKeyValue("authors", config);
-        QString description = PConfigMgr::getKeyValue("description", config);
-        QString mod_id = PConfigMgr::getKeyValue("mod_id", config);
-        QString version = PConfigMgr::getKeyValue("version", config);
-        QString path = ztd;
-        bool enabled = true; // Default to true
-        QString category = PConfigMgr::getKeyValue("category", config);
-        QString tags = PConfigMgr::getKeyValue("tags", config);
 
-        db.insertMod(title, // name of the mod
-                     description, // description
-                     authors.split(", "), // list of authors
-                     version, // version of the mod
-                     path, // file location
-                     enabled, // is it enabled or not
-                     tags.split(", "), // list of tags (aka collections)
-                     authors[0] + "." + title, // modId
-                     {}
-                    );
+        // Get values from config
+        PDatabaseMgr::PMod mod;
+        mod.title = PConfigMgr::getKeyValue("name", config);
+        mod.authors = PConfigMgr::getKeyValueAsList("authors", config);
+        mod.description = PConfigMgr::getKeyValue("description", config);
+        mod.path = ztd;
+        mod.enabled = true;
+        mod.category = PConfigMgr::getKeyValue("category", config);
+        mod.tags = PConfigMgr::getKeyValueAsList("tags", config);
+        mod.version = PConfigMgr::getKeyValue("version", config);
+        mod.mod_id = PConfigMgr::getKeyValue("mod_id", config);
+
+        db.insertMod(mod);
     }
 }

--- a/src/PController.cpp
+++ b/src/PController.cpp
@@ -235,7 +235,7 @@ void PController::loadModsFromZTDs(const QStringList &ztdList)
                 mod.tags = {"Unknown"};
             }
 
-            mod.category = tags[0];
+            mod.category = mod.tags[0];
             if (mod.category.isEmpty()) {
                 mod.category = "Unknown";
             }

--- a/src/PController.cpp
+++ b/src/PController.cpp
@@ -128,6 +128,12 @@ void PController::loadMods()
     // Load mods from ztds
     loadModsFromZTDs(ztdList);
 
+    // Open db
+    PDatabaseMgr db;
+    db.openDatabase();
+    // Get all mods from database
+    QSqlQuery query = db.getAllMods();
+
     // Add mods to list
     for (const QString &ztd : ztdList)
     {

--- a/src/PController.cpp
+++ b/src/PController.cpp
@@ -134,60 +134,23 @@ void PController::loadMods()
     // Get all mods from database
     QSqlQuery query = db.getAllMods();
 
-    // Add mods to list
-    for (const QString &ztd : ztdList)
+    // Iterate through the results and create PModItem objects
+    while (query.next())
     {
-        qDebug() << "Loading mod: " << ztd;
-        // Load mod from ZTD file
+        qDebug() << "Loading mod from database: " << query.value("title").toString();
         QSharedPointer<PModItem> mod = QSharedPointer<PModItem>::create();
-        qDebug() << "Created mod";
-        toml::table config = PConfigMgr::getMetaConfig(ztd);
-        qDebug() << "Got meta config";
-        mod->setmodTitle(PConfigMgr::getKeyValue("name", config));
-        qDebug() << "Set title" << PConfigMgr::getKeyValue("name", config);
-        
-        // Get list of authors from config to string
-        QString authors;
-        if (auto authorsArr = config["authors"].as_array())
-        {
-            if (authorsArr->empty())
-            {
-                authors = "Unknown";
-            }
-            else if (authorsArr->size() == 1)
-            {
-                authors = QString::fromStdString(authorsArr->at(0).as_string()->get());
-            }
-            else
-            {
-                QStringList authorList;
-
-                for (const auto &author : *authorsArr)
-                {
-                    authorList.append(QString::fromStdString(author.as_string()->get()));
-                }
-
-                authors = authorList.mid(0, authorList.size() - 1).join(", ") + " and " + authorList.last();
-            }
-        }
-        mod->setmodAuthor(authors);
-        mod->setmodDescription(PConfigMgr::getKeyValue("description", config));
-        mod->setmodPath(QUrl::fromLocalFile(ztd));
-        mod->setmodEnabled(true);
-        mod->setmodCategory(PConfigMgr::getKeyValue("category", config));
-        mod->setmodTags(PConfigMgr::getKeyValue("tags", config));
+        mod->setmodTitle(query.value("title").toString());
+        mod->setmodAuthor(query.value("authors").toString());
+        mod->setmodDescription(query.value("description").toString());
+        mod->setmodPath(QUrl::fromLocalFile(query.value("path").toString()));
+        mod->setmodEnabled(query.value("enabled").toBool());
+        mod->setmodCategory(query.value("category").toString());
+        mod->setmodTags(query.value("tags").toString());
         addMod(mod);
     }
-    
-    // QSharedPointer<PModItem> mod = QSharedPointer<PModItem>::create("Mod 1", "Author 1", "Description 1", QUrl("file:///path/to/mod1"), true, "Category 1", "Tag 1, Tag 2, Tag 3");
-    // addMod(mod);
 
-    // QSharedPointer<PModItem> mod2 = QSharedPointer<PModItem>::create("Mod 2", "Author 2", "Description 2", QUrl("file:///path/to/mod2"), true, "Category 2", "Tag 4, Tag 5, Tag 6");
-    // addMod(mod2);
-
-    // QSharedPointer<PModItem> mod3 = QSharedPointer<PModItem>::create("Mod 3", "Author 3", "Description 3", QUrl("file:///path/to/mod3"), true, "Category 3", "Tag 7, Tag 8, Tag 9");
-    // addMod(mod3);
-
+    db.closeDatabase();
+    qDebug() << "Loaded mods from database";
     endResetModel();
 }
 

--- a/src/PController.cpp
+++ b/src/PController.cpp
@@ -169,7 +169,10 @@ void PController::loadModsFromZTDs(const QStringList &ztdList)
 {
     // open database
     PDatabaseMgr db;
-    db.openDatabase();
+    if (!db.openDatabase()) {
+        qDebug() << "Failed to open database for loading mods from ZTDs";
+        return; // Failed to open database
+    }
 
     // Insert mods into database
     for (const QString &ztd : ztdList)

--- a/src/PController.cpp
+++ b/src/PController.cpp
@@ -186,3 +186,43 @@ void PController::addState(PState *state)
 {
     m_state = state;
 }
+
+// Grabs mods from SQLite database and adds them to the list to be displayed
+void PController::loadModsFromDatabase()
+{
+    // Placeholder for loading mods from database
+}
+
+// Grabs mods from ZTDs and stores them in database
+void PController::loadModsFromZTDs(const QStringList &ztdList)
+{
+    // open database
+    PDatabaseMgr db;
+    db.openDatabase();
+
+    // Insert mods into database
+    for (const QString &ztd : ztdList)
+    {
+        toml::table config = PConfigMgr::getMetaConfig(ztd);
+        QString title = PConfigMgr::getKeyValue("name", config);
+        QString authors = PConfigMgr::getKeyValue("authors", config);
+        QString description = PConfigMgr::getKeyValue("description", config);
+        QString mod_id = PConfigMgr::getKeyValue("mod_id", config);
+        QString version = PConfigMgr::getKeyValue("version", config);
+        QString path = ztd;
+        bool enabled = true; // Default to true
+        QString category = PConfigMgr::getKeyValue("category", config);
+        QString tags = PConfigMgr::getKeyValue("tags", config);
+
+        db.insertMod(title, // name of the mod
+                     description, // description
+                     authors.split(", "), // list of authors
+                     version, // version of the mod
+                     path, // file location
+                     enabled, // is it enabled or not
+                     tags.split(", "), // list of tags (aka collections)
+                     authors[0] + "." + title, // modId
+                     {}
+                    );
+    }
+}

--- a/src/PController.cpp
+++ b/src/PController.cpp
@@ -140,7 +140,7 @@ void PController::loadMods()
         qDebug() << "Loading mod from database: " << query.value("title").toString();
         QSharedPointer<PModItem> mod = QSharedPointer<PModItem>::create();
         mod->setmodTitle(query.value("title").toString());
-        mod->setmodAuthor(query.value("authors").toString());
+        mod->setmodAuthor(query.value("author").toString());
         mod->setmodDescription(query.value("description").toString());
         mod->setmodPath(QUrl::fromLocalFile(query.value("path").toString()));
         mod->setmodEnabled(query.value("enabled").toBool());

--- a/src/PController.cpp
+++ b/src/PController.cpp
@@ -239,6 +239,7 @@ void PController::loadModsFromZTDs(const QStringList &ztdList)
             }
 
             mod.category = mod.tags[0];
+            qDebug() << "Added category: " << mod.category << " to mod " << mod.title;
             if (mod.category.isEmpty()) {
                 mod.category = "Unknown";
             }

--- a/src/PController.cpp
+++ b/src/PController.cpp
@@ -203,21 +203,32 @@ void PController::loadModsFromZTDs(const QStringList &ztdList)
     // Insert mods into database
     for (const QString &ztd : ztdList)
     {
-        // Get meta config from ztd
-        toml::table config = PConfigMgr::getMetaConfig(ztd);
-
-        // Get values from config
         PDatabaseMgr::PMod mod;
-        mod.title = PConfigMgr::getKeyValue("name", config);
-        mod.authors = PConfigMgr::getKeyValueAsList("authors", config);
-        mod.description = PConfigMgr::getKeyValue("description", config);
-        mod.path = ztd;
-        mod.enabled = true;
-        mod.category = PConfigMgr::getKeyValue("category", config);
-        mod.tags = PConfigMgr::getKeyValueAsList("tags", config);
-        mod.version = PConfigMgr::getKeyValue("version", config);
-        mod.mod_id = PConfigMgr::getKeyValue("mod_id", config);
+
+        // Check if config exists
+        if (!PZtdMgr::fileExistsInZtd(ztd, m_metaConfigName)) {
+            qDebug() << "No meta config found in ztd: " << ztd;
+            continue; // Skip this ZTD file
+        }
+        else {
+
+            // Get meta config from ztd
+            toml::table config = PConfigMgr::getMetaConfig(ztd);
+
+            // Get values from config
+            mod.title = PConfigMgr::getKeyValue("name", config);
+            mod.authors = PConfigMgr::getKeyValueAsList("authors", config);
+            mod.description = PConfigMgr::getKeyValue("description", config);
+            mod.path = ztd;
+            mod.enabled = true;
+            mod.category = PConfigMgr::getKeyValue("category", config);
+            mod.tags = PConfigMgr::getKeyValueAsList("tags", config);
+            mod.version = PConfigMgr::getKeyValue("version", config);
+            mod.mod_id = PConfigMgr::getKeyValue("mod_id", config);
+
+        }
 
         db.insertMod(mod);
+
     }
 }

--- a/src/PController.cpp
+++ b/src/PController.cpp
@@ -206,9 +206,19 @@ void PController::loadModsFromZTDs(const QStringList &ztdList)
         PDatabaseMgr::PMod mod;
 
         // Check if config exists
-        if (!PZtdMgr::fileExistsInZtd(ztd, m_metaConfigName)) {
+        if (!PZtdMgr::fileExistsInZtd(ztd, "meta.toml")) {
             qDebug() << "No meta config found in ztd: " << ztd;
-            continue; // Skip this ZTD file
+            
+            // Insert mod with blank values
+            mod.title = "Unknown";
+            mod.authors = {"Unknown"};
+            mod.description = "No description found";
+            mod.path = ztd;
+            mod.enabled = true;
+            mod.category = "Unknown";
+            mod.tags = {"Unknown"};
+            mod.version = "1.0.0";
+            mod.mod_id = QUuid::createUuid().toString();
         }
         else {
 
@@ -217,14 +227,48 @@ void PController::loadModsFromZTDs(const QStringList &ztdList)
 
             // Get values from config
             mod.title = PConfigMgr::getKeyValue("name", config);
+            if (mod.title.isEmpty()) {
+                mod.title = "Unknown";
+            }
+
             mod.authors = PConfigMgr::getKeyValueAsList("authors", config);
+            if (mod.authors.isEmpty()) {
+                mod.authors = {"Unknown"};
+            }
+
             mod.description = PConfigMgr::getKeyValue("description", config);
+            if (mod.description.isEmpty()) {
+                mod.description = "No description found";
+            }
+
             mod.path = ztd;
             mod.enabled = true;
-            mod.category = PConfigMgr::getKeyValue("category", config);
+
             mod.tags = PConfigMgr::getKeyValueAsList("tags", config);
+            // remove "All" from tags if it exists
+            mod.tags.removeAll("All");
+            if (mod.tags.isEmpty()) {
+                mod.tags = {"Unknown"};
+            }
+
+            mod.category = tags[0];
+            if (mod.category.isEmpty()) {
+                mod.category = "Unknown";
+            }
+
+            if (mod.category.isEmpty()) {
+                mod.category = "Unknown";
+            }
+
             mod.version = PConfigMgr::getKeyValue("version", config);
+            if (mod.version.isEmpty()) {
+                mod.version = "1.0.0";
+            }
+
             mod.mod_id = PConfigMgr::getKeyValue("mod_id", config);
+            if (mod.mod_id.isEmpty()) {
+                mod.mod_id = QUuid::createUuid().toString();
+            }
 
         }
 

--- a/src/PController.cpp
+++ b/src/PController.cpp
@@ -190,12 +190,6 @@ void PController::addState(PState *state)
     m_state = state;
 }
 
-// Grabs mods from SQLite database and adds them to the list to be displayed
-void PController::loadModsFromDatabase()
-{
-    // Placeholder for loading mods from database
-}
-
 // Grabs mods from ZTDs and stores them in database
 // TODO: Add any errors to a list of errors to display to user
 // TODO: Add a check to see if mod already exists in database

--- a/src/PController.h
+++ b/src/PController.h
@@ -46,6 +46,8 @@ public:
     void deselectMod();
     void clearSelection();
     void loadMods();
+    void loadModsFromDatabase();
+    void loadModsFromZTDs(const QStringList &ztdList);
     void addState(PState *state);
 
     virtual int rowCount(const QModelIndex &parent) const override;

--- a/src/PController.h
+++ b/src/PController.h
@@ -51,7 +51,6 @@ public:
     void deselectMod();
     void clearSelection();
     void loadMods();
-    void loadModsFromDatabase();
     void loadModsFromZTDs(const QStringList &ztdList);
     void addState(PState *state);
 

--- a/src/PController.h
+++ b/src/PController.h
@@ -4,17 +4,22 @@
 /* This controller class will manipulate the state of the application. Mainly, it
 concerns itself with the mods list and operations over other classes from the UI. */
 
+// Qt includes
 #include <QObject>
 #include <QAbstractListModel>
 #include <QList>
-#include "PModItem.h"
 #include <QSharedPointer>
-#include "PState.h"
 #include <QStringList>
 #include <QVector>
+
+// Project includes
+#include "PModItem.h"
+#include "PState.h"
 #include "PZtdMgr.h"
 #include "PDatabaseMgr.h"
 #include "PConfigMgr.h"
+
+// Third-party includes
 #include "toml.hpp"
 
 class PModItem;

--- a/src/PDatabaseMgr.cpp
+++ b/src/PDatabaseMgr.cpp
@@ -374,3 +374,10 @@ bool PDatabaseMgr::doesKeyExist(const QString &modId, const QString &key) {
 
     return true;
 }
+
+QSqlQuery PDatabaseMgr::getAllMods() {
+    QSqlQuery query(m_db);
+    query.prepare("SELECT * FROM mods");
+    query.exec();
+    return query;
+}

--- a/src/PDatabaseMgr.cpp
+++ b/src/PDatabaseMgr.cpp
@@ -68,7 +68,8 @@ bool PDatabaseMgr::createTables() {
 
 bool PDatabaseMgr::insertMod(const QString &name, const QString &desc, const QVector<QString> &authors,
                              const QString &version, const QString &path, bool enabled, const QVector<QString> &tags,
-                             const QString &modId, const QVector<PDependency> &dependencies) {
+                             const QString category, const QString &modId, const QVector<PDependency> &dependencies) 
+                             {
     QSqlQuery query(m_db);
 
     // Check for missing required fields
@@ -77,8 +78,8 @@ bool PDatabaseMgr::insertMod(const QString &name, const QString &desc, const QVe
         return false;
     }
 
-    query.prepare("INSERT INTO mods (title, author, description, path, enabled, tags, version, mod_id) "
-                  "VALUES (:title, :author, :description, :path, :enabled, :tags, :version, :mod_id)");
+    query.prepare("INSERT INTO mods (title, author, description, path, enabled, tags, category, version, mod_id) "
+                  "VALUES (:title, :author, :description, :path, :enabled, :tags, :category, :version, :mod_id)");
     
     // Bind required values
     query.bindValue(":title", name);
@@ -126,6 +127,14 @@ bool PDatabaseMgr::insertMod(const QString &name, const QString &desc, const QVe
         query.bindValue(":tags", "");
     }
 
+    // add category to category field
+    if (!tags.isEmpty()) {
+        query.bindValue(":category", category);
+    }
+    else {
+        query.bindValue(":category", "Uncategorized");
+    }
+
     // Execute the query
     if (!query.exec()) {
         qDebug() << "Failed to insert mod: " << query.lastError();
@@ -147,8 +156,9 @@ bool PDatabaseMgr::insertMod(const QString &name, const QString &desc, const QVe
     return true;
 }
 
+// TODO: Fix tags so they insert as a list
 bool PDatabaseMgr::insertMod(const PMod &mod) {
-    return insertMod(mod.title, mod.description, {mod.authors}, mod.version, mod.path, mod.enabled, mod.tags, mod.mod_id, mod.dependencies);
+    return insertMod(mod.title, mod.description, {mod.authors}, mod.version, mod.path, mod.enabled, mod.tags, mod.category, mod.mod_id, mod.dependencies);
 }
 
 bool PDatabaseMgr::deleteMod(const QString &modId) {

--- a/src/PDatabaseMgr.h
+++ b/src/PDatabaseMgr.h
@@ -47,7 +47,7 @@ public:
     bool createTables();
     bool insertMod(const QString &name, const QString &desc, const QVector<QString> &authors,
                    const QString &version, const QString &path, bool enabled, const QVector<QString> &tags,
-                   const QString &modId, const QVector<PDependency> &dependencies);
+                     const QString category, const QString &modId, const QVector<PDependency> &dependencies);
     bool insertMod(const PMod &mod);
     bool deleteMod(const QString &modId);
     bool updateMod(const QString &modId, const QString &key, const QString &value);

--- a/src/PDatabaseMgr.h
+++ b/src/PDatabaseMgr.h
@@ -59,7 +59,7 @@ public:
     QSqlQuery orderBy(const QString &query);
     QSqlQuery searchMods(const QString &searchTerm);
     QSqlQuery getModByPk(const QString &modId);
-    QString getDbName() const { return m_dbName; }
+    static QString getDbName() const { return m_dbName; }
 
     bool doesModExist(const QString &modId);
     bool doesDependencyExist(const QString &dependencyId);

--- a/src/PDatabaseMgr.h
+++ b/src/PDatabaseMgr.h
@@ -59,6 +59,7 @@ public:
     QSqlQuery orderBy(const QString &query);
     QSqlQuery searchMods(const QString &searchTerm);
     QSqlQuery getModByPk(const QString &modId);
+    QString getDbName() const { return m_dbName; }
 
     bool doesModExist(const QString &modId);
     bool doesDependencyExist(const QString &dependencyId);

--- a/src/PDatabaseMgr.h
+++ b/src/PDatabaseMgr.h
@@ -31,12 +31,12 @@ public:
     struct PMod
     {
         QString title;
-        QString authors;
+        QVector<QString> authors;
         QString description;
         QString path;
         bool enabled;
         QString category;
-        QStringList tags;
+        QVector<QString> tags;
         QString version;
         QString mod_id;
         QVector<PDependency> dependencies;

--- a/src/PDatabaseMgr.h
+++ b/src/PDatabaseMgr.h
@@ -59,7 +59,6 @@ public:
     QSqlQuery orderBy(const QString &query);
     QSqlQuery searchMods(const QString &searchTerm);
     QSqlQuery getModByPk(const QString &modId);
-    static QString getDbName() const { return m_dbName; }
 
     bool doesModExist(const QString &modId);
     bool doesDependencyExist(const QString &dependencyId);


### PR DESCRIPTION
- Revamps the loadMods function to now load ZTD files from the install directory
- Look for meta.toml files in ztd. If exist, populate with data. If not, add blank fields.
- Check if mod exists already in database
- Inserts  all mod data into local SQLite database
- Loads list of mods from this db into the UI 